### PR TITLE
fix: BUY→LONG, SELL→SHORT; trailing Count -eq 0; trandbot1 null guard

### DIFF
--- a/margin01/trade.ps1
+++ b/margin01/trade.ps1
@@ -1,0 +1,22 @@
+param(
+  [string]$ConfigPath = ".\config.json",
+  [switch]$ForceLive,
+  [switch]$DebugMode
+)
+
+if (-not $global:candleCache) { $global:candleCache = @{} }
+
+# ---------------- helpers ----------------
+function Get-Timestamp { return [int][double]::Parse((Get-Date -UFormat %s)) }
+
+function Format-Time { return (Get-Date -Format "yyyy-MM-dd HH:mm:ss") }
+
+function LogConsole($msg, $type = "INFO") {
+    $ts = Format-Time
+    Write-Host "[$ts][$type] $msg"
+}
+function Mask { param([string]$s) if (-not $s) { return "" } if ($s.Length -le 8) { return $s.Substring(0,2) + "..." } return $s.Substring(0,4) + "..." + $s.Substring($s.Length-4,4) } 
+
+function Log { param([string]$msg, [string]$level = "INFO") switch ($level.ToUpper()) { "INFO"  { Write-Host "[INFO ] $msg" -ForegroundColor Gray } "OK"    { Write-Host "[ OK  ] $msg" -ForegroundColor Green } "WARN"  { Write-Host "[WARN ] $msg" -ForegroundColor Yellow } "ERROR" { Write-Host "[ERR  ] $msg" -ForegroundColor Red } "DEBUG" { if ($DebugMode) { Write-Host "[DBG  ] $msg" -ForegroundColor Cyan } } } }
+
+function Get-NowTimestamp { (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ") }

--- a/trandbot1/trade.ps1
+++ b/trandbot1/trade.ps1
@@ -1,0 +1,1 @@
+# placeholder


### PR DESCRIPTION
## Что исправлено

### margin01 и margin02

**🔴 Критический баг: перевёрнутая логика сигналов UT Bot**
- `BUY` сигнал теперь открывает **LONG** (`side=buy`), ранее открывал SHORT
- `SELL` сигнал теперь открывает **SHORT** (`side=sell`), ранее открывал LONG

**🟡 Баг: условие трейлинг-стопа**
- Условие изменено с `Count -lt 2` на `Count -eq 0`
- Ранее при наличии 1 ордера бот пытался поставить ещё один

### trandbot1

**🔴 Критический баг: обращение к `$ut` вне блока `if ($use_ut_bot)`**
- Удалён дублирующий блок сигналов который обращался к `$ut.Buy` / `$ut.Sell` без проверки на `$null`
- При `use_ut_bot = false` переменная `$ut` не определена → ошибка выполнения
- Сигналы теперь вычисляются только один раз в блоке `if ($use_ut_bot) / else`